### PR TITLE
CI: Fix broken OSX tests

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -49,12 +49,13 @@ jobs:
             extra_packages: 'clang-tidy-15'
             standard: '17'
             os-release: '22.04'
-        build_type: ['Release']
         build_libs: ['shared static']
+        build_type: ['Release']
         compiler: ['gcc-10', 'gcc-11', 'gcc-12', 'gcc-13', 'clang-13', 'clang-14', 'clang-15']
         extra_args: ['--num-tasks=256 --tbb']
-        standard: ['11', '17']
+        extra_ctest: ['']
         os-release: ['22.04']
+        standard: ['11', '17']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -18,8 +18,10 @@ jobs:
         build_type: ["Release"]
         compiler: ["clang-13", "clang-14"]
         extra_args: ["--num-tasks=256 --tbb"]
+        extra_cmake: [""]
+        extra_ctest: [""]
         extra_packages: ["clangdev tbb-devel"]
-        os-release: ["macos-11", "macos-12", "macos-13""]
+        os-release: ["macos-11", "macos-12", "macos-13"]
         standard: ["11", "17"]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Noticed that the OSX tests weren't running due to syntax error. So fixed that and warnings from the Github Actions YAML linter.