### PR TITLE
Fix CUDA 12.4 Compiler Error

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -21,7 +21,7 @@ jobs:
         extra_cmake: [""]
         extra_ctest: [""]
         extra_packages: ["clangdev tbb-devel"]
-        os-release: ["macos-11", "macos-12", "macos-13"]
+        os-release: ["macos-13"]
         standard: ["11", "17"]
     steps:
       - uses: actions/checkout@v2

--- a/source/PTL/TaskGroup.hh
+++ b/source/PTL/TaskGroup.hh
@@ -654,14 +654,16 @@ TaskGroup<Tp, Arg, MaxDepth>::join(Up accum)
 {
     this->wait();
     for(auto& itr : m_task_list)
-    {
-        using RetT = decay_t<decltype(itr->get())>;
-        accum      = std::move(m_join(std::ref(accum), std::forward<RetT>(itr->get())));
+    {        
+        auto&& ret = itr->get();
+        using RetT = decay_t<decltype(ret)>;
+        accum      = std::move(m_join(std::ref(accum), std::forward<RetT>(ret)));
     }
     for(auto& itr : m_future_list)
-    {
-        using RetT = decay_t<decltype(itr.get())>;
-        accum      = std::move(m_join(std::ref(accum), std::forward<RetT>(itr.get())));
+    {        
+        auto&& ret = itr.get();
+        using RetT = decay_t<decltype(ret)>;
+        accum      = std::move(m_join(std::ref(accum), std::forward<RetT>(ret)));
     }
     this->clear();
     return accum;
@@ -691,13 +693,15 @@ TaskGroup<Tp, Arg, MaxDepth>::join()
     this->wait();
     for(auto& itr : m_task_list)
     {
-        using RetT = decay_t<decltype(itr->get())>;
-        m_join(std::forward<RetT>(itr->get()));
+        auto&& ret = itr->get();
+        using RetT = decay_t<decltype(ret)>;
+        m_join(std::forward<RetT>(ret));
     }
     for(auto& itr : m_future_list)
     {
-        using RetT = decay_t<decltype(itr.get())>;
-        m_join(std::forward<RetT>(itr.get()));
+        auto&& ret = itr.get();
+        using RetT = decay_t<decltype(ret)>;
+        m_join(std::forward<RetT>(ret));
     }
     this->clear();
 }

--- a/source/PTL/TaskGroup.hh
+++ b/source/PTL/TaskGroup.hh
@@ -654,13 +654,13 @@ TaskGroup<Tp, Arg, MaxDepth>::join(Up accum)
 {
     this->wait();
     for(auto& itr : m_task_list)
-    {        
+    {
         auto&& ret = itr->get();
         using RetT = decay_t<decltype(ret)>;
         accum      = std::move(m_join(std::ref(accum), std::forward<RetT>(ret)));
     }
     for(auto& itr : m_future_list)
-    {        
+    {
         auto&& ret = itr.get();
         using RetT = decay_t<decltype(ret)>;
         accum      = std::move(m_join(std::ref(accum), std::forward<RetT>(ret)));


### PR DESCRIPTION
When trying to call decltype on the get() component, CUDA 12.4 fails to compile. 

To bypass this, a new variable is instantiated, auto is used to infer the type of the variable, and then the type is read from the new variable for the following statement. 

Testing was performed on both PTL and tomopy test suites. We'll see if it holds up across the full suite of compilers. 

NOTE: Current tomopy submodule points to this branch. Should consider merging this branch into master. 